### PR TITLE
Return value transform function

### DIFF
--- a/src/DataLoader/DataLoaderContext.cs
+++ b/src/DataLoader/DataLoaderContext.cs
@@ -8,14 +8,14 @@ using System.Threading.Tasks;
 namespace DataLoader
 {
     /// <summary>
-    /// Defines a context for creating and executing <see cref="DataLoader{TKey,TReturn}"/> instances.
+    /// Defines a context for creating and executing <see cref="DataLoader{TKey,TValue,TReturn}"/> instances.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This class contains any data required by <see cref="DataLoader{TKey,TReturn}"/> instances and is responsible for managing their execution.
+    /// This class contains any data required by <see cref="DataLoader{TKey,TValue,TReturn}"/> instances and is responsible for managing their execution.
     /// </para>
     /// <para>
-    /// Loaders enlist themselves with the context active at the time when the <see cref="DataLoader{TKey,TReturn}.LoadAsync"/> method is called.
+    /// Loaders enlist themselves with the context active at the time when the <see cref="DataLoader{TKey,TValue,TReturn}.LoadAsync"/> method is called.
     /// Later, when the context is completed (using the <see cref="CompleteAsync"/> method), the queue will be processed and each loader executed
     /// in the order they were enlisted.
     /// </para>
@@ -37,9 +37,17 @@ namespace DataLoader
         /// <summary>
         /// Retrieves a cached loader for the given key, creating one if none is found.
         /// </summary>
-        public IDataLoader<TKey, TReturn> GetOrCreateLoader<TKey, TReturn>(object key, Func<IEnumerable<TKey>, Task<ILookup<TKey, TReturn>>> fetch)
+        public IDataLoader<TKey, TValue> GetOrCreateLoader<TKey, TValue>(object key, Func<IEnumerable<TKey>, Task<ILookup<TKey, TValue>>> fetch)
         {
-            return (IDataLoader<TKey, TReturn>)_cache.GetOrAdd(key, _ => new DataLoader<TKey, TReturn>(fetch, this));
+            return (IDataLoader<TKey, TValue>)_cache.GetOrAdd(key, _ => new DataLoader<TKey, TValue>(fetch, this));
+        }
+
+        /// <summary>
+        /// Retrieves a cached loader for the given key, creating one if none is found.
+        /// </summary>
+        public IDataLoader<TKey, TValue, TReturn> GetOrCreateLoader<TKey, TValue, TReturn>(object key, Func<IEnumerable<TKey>, Task<ILookup<TKey, TValue>>> fetch, Func<IEnumerable<TValue>, TReturn> transform)
+        {
+            return (IDataLoader<TKey, TValue, TReturn>)_cache.GetOrAdd(key, _ => new DataLoader<TKey, TValue, TReturn>(fetch, transform, this));
         }
 
         /// <summary>


### PR DESCRIPTION
I have been looking to use this library with GraphQL and came across a situation where I wanted to use the data loader but I was only loading a single item for each key and so wanted to resolve to type `T` rather than `ListGraphType<T>`.  I couldn't find a way to do this without forking your code and making some changes (if there is a way I guess you can kill this pull request but I'd be interest to know how to do it).  This changes the main interface to `IDataLoader<TKey, TValue, TReturn>` and the implementation constructor now requires a transform function `Func<IEnumerable<TValue>, TReturn>`.   In the case I mentioned above this allows me to provide the following function: `r => r.FirstOrDefault()`.  This will not break any existing implementations as there is still an `IDataLoader<TKey, TValue>` interface (`IDataLoader<TKey, TValue, IEnumerable<TValue>`) and `DataLoader<TKey, TValue>` class (`DataLoader<TKey, TValue, IEnumerable<TValue>` with transform function `r => r`).